### PR TITLE
Added documentation about composer package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ The full quick start and reference docs can be found at: https://www.calq.io/doc
 Installation
 ------------
 
+###Using composer (recommended)
+
+Install the [latest release](https://packagist.org/packages/calq/calq) of the library through Composer with the following command:
+
+```bash
+composer require calq/calq
+```
+
+###Old-style copy-and-paste
+
 Grab the [latest release](https://github.com/Calq/Client-PHP/releases) and add it to your project.
 
 You will need to include the CalqClient library where you intend to use it. The library requires PHP 5.2 or higher.


### PR DESCRIPTION
I think it's a really good idea to specify into the documentation that the composer package is available.

I admit I was quite scared about the library quality when I've seen the old copy and paste method for the installation.
